### PR TITLE
feat: upgrade hpa version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: swaggerui
-version: 0.4.0
+version: 0.4.1
 appVersion: 3.24.3
 description: Swagger is an open-source software framework backed by a large ecosystem of tools that helps developers design, build, document, and consume RESTful Web services.
 keywords:

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "swagger-ui.fullname" . }}


### PR DESCRIPTION
autoscaling/v2beta1 is deprecated since kube 1.23
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125